### PR TITLE
#179 - nem információs modal-ok nem zárhatók be a háttérre kattintva

### DIFF
--- a/src/shared/component/modal/Overlay.jsx
+++ b/src/shared/component/modal/Overlay.jsx
@@ -21,12 +21,13 @@ export default connect(mapStateToProps, { closeModal })(
           <div className="modal-backdrop fade show" />
           {modals.map(({ modal: Modal, id, parameters }, idx) => {
             const close = pipe(parameters.onClose, () => closeModal(id))
+            const hasBackdropClose = !parameters.disableBackdropClose
             return (
               <div
                 key={id}
                 className={`d-block modal fade show ${modals.length - 1 === idx ? 'active-modal' : ''}`}
                 role="dialog"
-                onClick={e => e.target === e.currentTarget && close()}
+                onClick={hasBackdropClose && (e => e.target === e.currentTarget && close())}
               >
                 <Modal {...parameters} close={close} />
               </div>

--- a/src/shared/store/actions/modal.js
+++ b/src/shared/store/actions/modal.js
@@ -71,6 +71,7 @@ export function openInputModal(params) {
     value: '',
     onClose: identity,
     onUpdate: identity,
+    disableBackdropClose: true,
     ...params
   })
 }
@@ -79,6 +80,7 @@ export function openFileManager(params) {
   return openModal(FileManager, {
     onClose: identity,
     onSelect: identity,
+    disableBackdropClose: true,
     ...params
   })
 }
@@ -94,6 +96,7 @@ export function openUserControlModal(params) {
   return openModal(UserControlModal, {
     onClose: identity,
     onUpdate: identity,
+    disableBackdropClose: true,
     ...params
   })
 }
@@ -120,6 +123,7 @@ export function openFileUpload(params) {
     onSuccess: identity,
     onError: identity,
     resources: [],
+    disableBackdropClose: true,
     ...params
   })
 }


### PR DESCRIPTION
Javított hibajegy: #179 

Változások: csak információs modálok zárhatók be a modál mögötti szürke háttérre kattintással, ezzel elkerülve az esetleges adatvesztéssel járó véletlen bezárásokat.
