### PR TITLE
#215 - részfeladatok dnd javítása

### DIFF
--- a/src/shared/component/general/Sortable.jsx
+++ b/src/shared/component/general/Sortable.jsx
@@ -17,12 +17,13 @@ function itemSource(ctx) {
   return {
     beginDrag(props) {
       return {
-        index: props.index
+        index: props.index,
+        originalIndex: props.index
       }
     },
 
     endDrag(props, monitor) {
-      ctx.dndFinish()
+      ctx.dndFinish(monitor.getItem())
     }
   }
 }
@@ -88,9 +89,9 @@ export const Sortable = DragDropContext(HTML5Backend)(
       return null
     }
 
-    dndFinish() {
+    dndFinish(lastItem) {
       const { onChange } = this.props
-      if (onChange) onChange(unwrapSortableList(this.state.list))
+      if (onChange) onChange(unwrapSortableList(this.state.list), lastItem)
     }
 
     render() {


### PR DESCRIPTION
**Javított hibajegy:** #215

**Változások:**
 - részfeladatok rendezés javítása
 - az akatív tab a mozgatott részfeladatra ugrik és frissíti a tab tartalmát