### PR TITLE
Update DonateButton.jsx

### DIFF
--- a/src/public/component/DonateButton.jsx
+++ b/src/public/component/DonateButton.jsx
@@ -8,7 +8,7 @@ export default () => {
         <input type="hidden" name="cmd" value="_s-xclick" />
         <input type="hidden" name="hosted_button_id" value="Y389SASDEHF9A" />
         <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!" />
-        <img alt="Támogatás Paypal-en keresztül" border="0" src="https://www.paypalobjects.com/hu_HU/i/scr/pixel.gif" width="1" height="1" />
+        <img alt="" border="0" src="https://www.paypalobjects.com/hu_HU/i/scr/pixel.gif" width="1" height="1" />
       </form>
     </div>)
 }


### PR DESCRIPTION
Úgy tűnik, hogy direkt nem volt lefordítva az alt szöveg... Ugyanis a https://www.paypalobjects.com/hu_HU/i/scr/pixel.gif nem található, és ezért mindig kiírja az alt szöveget.

**Változások:**
Alt szöveg törlése