### PR TITLE
 #368 Kulcsszavak & találatok mentése 

### DIFF
--- a/src/client-public/page/Search.tsx
+++ b/src/client-public/page/Search.tsx
@@ -58,10 +58,11 @@ export const Search = pipe(
         this.setState({ loading: true, list: undefined })
         this.props.history.push({ search: `q=${term}` })
 
-        ReactGA.event({ category: 'User', action: 'Search', value: term })
-
         search(term)
-          .then(list => this.setState({ list, error: undefined, loading: false, term }))
+          .then(list => {
+            this.setState({ list, error: undefined, loading: false, term })
+            if (list) { ReactGA.event({ category: 'User', action: 'Search results', label: term, value: list.nbHits })}
+          })
           .catch(error => this.setState({ error, loading: false }))
       } else {
         this.props.history.push({ search: `` })


### PR DESCRIPTION
**Javított hibajegy:** #368 

**Változások:**
 - Search.tsx: keresés kulcsszó és találatok számának elküldése a Google Analytics felé. A kulcsszót a `label,` a találatok számát a `value` property tartalmazza. Kivettem a korábbi statisztika-küldést, ami csak a kulcsszót tartalmazta, mert hibát dobott (a `value`-ban próbáltuk elküldeni, ami csak `int` lehet).